### PR TITLE
Ruleset to have custom max_age per projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ I created a series of projects locally and then used the `max_age_in_hours` set 
 
 Test doing something like this:
 
-- Modify `projects.yml` to have a short `max_age_in_hours`:
+- Modify `settings.yml` to have a short `default_max_age_in_hours`:
 
 ```yaml
 endpoint:
@@ -56,6 +56,7 @@ endpoint:
   # either...
   username: developer
   password: developer
+  options: --insecure-skip-tls-verify
   # or...
   # token: xyz
 projects:
@@ -75,7 +76,10 @@ projects:
     - sysint
     - test
     - uat
-max_age_in_hours: 1
+  rules:
+    - project: "^at-.*"
+      max_age_in_hours: 18
+default_max_age_in_hours: 48
 ```
 
 - Run the following commands:

--- a/reap_projects.py
+++ b/reap_projects.py
@@ -5,10 +5,28 @@ from pprint import pprint
 from openshift import client, config
 from yaml import load, dump
 import subprocess
+import re
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
     from yaml import Loader, Dumper
+
+def matching_rule(project_name):
+    for rule in data['projects']['rules']:
+        pattern = re.compile(rule['project'])
+        pattern.match(project_name)
+        if pattern.match(project_name):
+            return rule
+    return None
+
+def process_project(project, max_age_in_hours):
+    print "Project {} was created {}".format(project.metadata.name,project.metadata.creation_timestamp)
+    if project_createtime < now - timedelta(hours = max_age_in_hours):
+        print "  REAPING {} AS IT IS OLDER THAN {} HOURS".format(project.metadata.name,max_age_in_hours)
+        oapi.delete_project(project.metadata.name)
+    else:
+        print "  Young enough to survive the {}h reaper".format(max_age_in_hours)
+
 
 with open("settings.yml", 'r') as stream:
     data = load(stream)
@@ -28,16 +46,13 @@ config.load_kube_config()
 oapi             = client.OapiApi()
 project_list     = oapi.list_project()
 now              = datetime.utcnow()
-max_age_in_hours = data['max_age_in_hours']
+default_max_age_in_hours = data['default_max_age_in_hours']
 
 for project in project_list.items:
     project_createtime = datetime.strptime(project.metadata.creation_timestamp, '%Y-%m-%dT%H:%M:%SZ')
     if project.metadata.name in data['projects']['preserve']:
         print "Project {} is whitelisted and will not be deleted".format(project.metadata.name)
+    elif matching_rule(project.metadata.name) is not None:
+        process_project(project, matching_rule(project.metadata.name)['max_age_in_hours'])
     else:
-        print "Project {} was created {}".format(project.metadata.name,project.metadata.creation_timestamp)
-        if project_createtime < now - timedelta(hours = max_age_in_hours):
-            print "  REAPING {} AS IT IS OLDER THAN {} HOURS".format(project.metadata.name,max_age_in_hours)
-            oapi.delete_project(project.metadata.name)
-        else:
-            print "  Young enough to survive the reaper"
+        process_project(project, default_max_age_in_hours)

--- a/reap_projects.py
+++ b/reap_projects.py
@@ -48,11 +48,18 @@ project_list     = oapi.list_project()
 now              = datetime.utcnow()
 default_max_age_in_hours = data['default_max_age_in_hours']
 
+filtered_projects = []
 for project in project_list.items:
-    project_createtime = datetime.strptime(project.metadata.creation_timestamp, '%Y-%m-%dT%H:%M:%SZ')
     if project.metadata.name in data['projects']['preserve']:
         print "Project {} is whitelisted and will not be deleted".format(project.metadata.name)
-    elif matching_rule(project.metadata.name) is not None:
+    else:
+        filtered_projects.append(project)
+
+print "\n"
+
+for project in filtered_projects:
+    project_createtime = datetime.strptime(project.metadata.creation_timestamp, '%Y-%m-%dT%H:%M:%SZ')
+    if matching_rule(project.metadata.name) is not None:
         process_project(project, matching_rule(project.metadata.name)['max_age_in_hours'])
     else:
         process_project(project, default_max_age_in_hours)

--- a/settings.yml.sample
+++ b/settings.yml.sample
@@ -23,4 +23,7 @@ projects:
     - sysint
     - test
     - uat
-max_age_in_hours: 48
+  rules:
+    - project: "^at-.*"
+      max_age_in_hours: 18
+default_max_age_in_hours: 48


### PR DESCRIPTION
The yaml is extended with a ruleset to apply custom max age values for projects that match a regexp.

Breaking change: `max_age_in_hours was` renamed to `default_max_age_in_hours`