### PR TITLE
Add error handling for API delete project call

### DIFF
--- a/reap_projects.py
+++ b/reap_projects.py
@@ -2,8 +2,11 @@
 
 from datetime import timedelta, datetime
 from pprint import pprint
+import urllib3
 from openshift import client, config
+from kubernetes.client.rest import ApiException
 from yaml import load, dump
+from pprint import pprint
 import subprocess
 import re
 try:
@@ -20,16 +23,26 @@ def matching_rule(project_name):
     return None
 
 def process_project(project, max_age_in_hours):
-    print "Project {} was created {}".format(project.metadata.name,project.metadata.creation_timestamp)
-    if project_createtime < now - timedelta(hours = max_age_in_hours):
-        print "  REAPING {} AS IT IS OLDER THAN {} HOURS".format(project.metadata.name,max_age_in_hours)
-        oapi.delete_project(project.metadata.name)
+    print "Project {} was created {}".format(
+        project.metadata.name, project.metadata.creation_timestamp)
+    if project_createtime < now - timedelta(hours=max_age_in_hours):
+        print "  REAPING {} AS IT IS OLDER THAN {} HOURS".format(
+            project.metadata.name, max_age_in_hours)
+        try:
+            oapi.api_response = oapi.delete_project(project.metadata.name)
+            pprint(api_response)
+        except ApiException as e:
+            print("Exception when trying to delete project: %s\n" % e)
     else:
-        print "  Young enough to survive the {}h reaper".format(max_age_in_hours)
+        print "  Young enough to survive the {}h reaper".format(
+            max_age_in_hours)
 
 
 with open("settings.yml", 'r') as stream:
     data = load(stream)
+
+# Disable SSL warnings
+urllib3.disable_warnings()
 
 # FIXME Authentication should be via pyhton API
 if data['endpoint'].has_key('token'):


### PR DESCRIPTION
Found that if a project was stuck being deleted, then the next call
from the reaper to delete the same project would cause an unhandled
error.  The error would cause the program to terminate without
attempting to process further projects in the list.

This commit adds some error handling so the project is simply
skipped if busy.  Also remove the SSL warnings as its difficult to debug
real issue with so much noise in the output.